### PR TITLE
FYR-384 Serialize schema as part of ES 2x upgrade

### DIFF
--- a/pseudonym/manager.py
+++ b/pseudonym/manager.py
@@ -26,7 +26,7 @@ class SchemaManager(object):
             self._strategies = None
             schema = self.client.get(index=self.schema_index, id='master')
             source = schema.pop('_source')
-            schema_doc = source.get('schema')
+            schema_doc = source.get('schema', source)
             if isinstance(schema_doc, basestring):
                 schema_doc = json.loads(schema_doc)
             self._schema = schema, schema_doc

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pseudonym",
-    version="0.4.0",
+    version="0.5.0",
     author="Jonathan Klaassen",
     author_email="jonathan@livefyre.com",
     description=("A library for configuring elasticsearch aliases."),

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,5 +1,6 @@
 import datetime
 import unittest
+import json
 
 from elasticsearch.client import Elasticsearch
 from pseudonym.manager import SchemaManager
@@ -16,47 +17,60 @@ class TestSchemaManager(unittest.TestCase):
         self.client.indices.delete(self.test_schema_index)
 
     def test_schema_compiling(self):
-        cfg = {'aliases': [{'name': 'alias1', 'strategy': {'date': {'indexes': {'201401': datetime.date(2014, 1, 1)}}}}]}
+        cfg = {'aliases': [{'name': 'alias1', 'strategy': {'date': {'indexes': {'201401': datetime.date(2014, 1, 1).isoformat()}}}}]}
         self.manager.update(cfg)
 
         schema = self.client.get(index=self.test_schema_index, id='master')
         self.assertEqual(schema['_version'], 1)
-        self.assertEqual({a['name'] for a in schema['_source']['aliases']}, {'alias1'})
-        self.assertEqual({i['name'] for i in schema['_source']['indexes']}, {'201401'})
+        source = schema.pop('_source')
+        schema_doc = json.loads(source.get('schema'))
 
-        cfg['aliases'][0]['strategy']['date']['indexes']['201402'] = datetime.date(2014, 2, 1)
+        self.assertEqual({a['name'] for a in schema_doc['aliases']}, {'alias1'})
+        self.assertEqual({i['name'] for i in schema_doc['indexes']}, {'201401'})
+
+        cfg['aliases'][0]['strategy']['date']['indexes']['201402'] = datetime.date(2014, 2, 1).isoformat()
         self.manager.update(cfg)
         schema = self.client.get(index=self.test_schema_index, id='master')
         self.assertEqual(schema['_version'], 2)
-        self.assertEqual({a['name'] for a in schema['_source']['aliases']}, {'alias1'})
-        self.assertEqual({i['name'] for i in schema['_source']['indexes']}, {'201401', '201402'})
+        source = schema.pop('_source')
+        schema_doc = json.loads(source.get('schema'))
 
-        cfg['aliases'].append({'name': 'alias2', 'strategy': {'date': {'indexes': {'201501': datetime.date(2015, 1, 1)}}}})
+        self.assertEqual({a['name'] for a in schema_doc['aliases']}, {'alias1'})
+        self.assertEqual({i['name'] for i in schema_doc['indexes']}, {'201401', '201402'})
+
+        cfg['aliases'].append({'name': 'alias2', 'strategy': {'date': {'indexes': {'201501': datetime.date(2015, 1, 1).isoformat()}}}})
 
         self.manager.update(cfg)
         schema = self.client.get(index=self.test_schema_index, id='master')
         self.assertEqual(schema['_version'], 3)
-        self.assertEqual({a['name'] for a in schema['_source']['aliases']}, {'alias1', 'alias2'})
-        self.assertEqual({i['name'] for i in schema['_source']['indexes']}, {'201401', '201402', '201501'})
+        source = schema.pop('_source')
+        schema_doc = json.loads(source.get('schema'))
+
+        self.assertEqual({a['name'] for a in schema_doc['aliases']}, {'alias1', 'alias2'})
+        self.assertEqual({i['name'] for i in schema_doc['indexes']}, {'201401', '201402', '201501'})
 
     def test_add_index(self):
-        cfg = {'aliases': [{'name': 'alias1', 'strategy': {'date': {'indexes': {'201401': datetime.date(2014, 1, 1)}}}}]}
+        cfg = {'aliases': [{'name': 'alias1', 'strategy': {'date': {'indexes': {'201401': datetime.date(2014, 1, 1).isoformat()}}}}]}
         self.manager.update(cfg)
         self.manager.add_index('alias1', '201402', datetime.date(2014, 1, 2).isoformat())
         schema = self.client.get(index=self.test_schema_index, id='master')
+        source = schema.pop('_source')
+        schema_doc = json.loads(source.get('schema'))
 
-        for alias in schema['_source']['aliases']:
+        for alias in schema_doc['aliases']:
             if alias['name'] == 'alias1':
                 break
         self.assertIn('201402', alias['indexes'])
-        self.assertIn('201402', [i['name'] for i in schema['_source']['indexes']])
+        self.assertIn('201402', [i['name'] for i in schema_doc['indexes']])
 
     def test_remove_index(self):
-        cfg = {'aliases': [{'name': 'alias1', 'strategy': {'date': {'indexes': {'201501': datetime.date(2015, 1, 1), '201401': datetime.date(2014, 1, 1)}}}}]}
+        cfg = {'aliases': [{'name': 'alias1', 'strategy': {'date': {'indexes': {'201501': datetime.date(2015, 1, 1).isoformat(), '201401': datetime.date(2014, 1, 1).isoformat()}}}}]}
         self.manager.update(cfg)
         self.manager.remove_index('201401')
         schema = self.client.get(index=self.test_schema_index, id='master')['_source']
-        self.assertEqual(len(schema['indexes']), 1)
-        self.assertEqual(schema['indexes'][0]['name'], '201501')
-        self.assertEqual(len(schema['aliases']), 1)
-        self.assertEqual(schema['aliases'][0]['indexes'], ['201501'])
+        schema_doc = json.loads(schema.get('schema'))
+
+        self.assertEqual(len(schema_doc['indexes']), 1)
+        self.assertEqual(schema_doc['indexes'][0]['name'], '201501')
+        self.assertEqual(len(schema_doc['aliases']), 1)
+        self.assertEqual(schema_doc['aliases'][0]['indexes'], ['201501'])


### PR DESCRIPTION
ES 2.x does not allow dot notation field names, and pseudonym index stores index.routing.allocation.require.storage_type as a schema setting.  So just serialize the entire schema to make things easier.