### PR TITLE
FYR-384 - Downgrade ES client due to scrolling incompat with ES 1.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docopt==0.6.1
-elasticsearch>=2.4
+elasticsearch==2.3
 mock>=1.0.1
 nose==1.3.7
 requests>=2.2.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pseudonym",
-    version="0.5.1",
+    version="0.5.2",
     author="Jonathan Klaassen",
     author_email="jonathan@livefyre.com",
     description=("A library for configuring elasticsearch aliases."),


### PR DESCRIPTION
Scrolling shouldn't be used much in pseudonym itself, but SI nodejs lib uses this and lfdj uses that. LFDJ ends up pulling the ES client from here (at least in Circle), so version needs to match lfdj version.